### PR TITLE
Fix WGSL syntax and WebGPU usage warnings in Chrome Canary

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -220,15 +220,17 @@ export default class Renderer {
     encodeCommands() {
         let colorAttachment: GPURenderPassColorAttachment = {
             view: this.colorTextureView,
-            loadValue: { r: 0, g: 0, b: 0, a: 1 },
+            clearValue: { r: 0, g: 0, b: 0, a: 1 },
+            loadOp: 'clear',
             storeOp: 'store'
         };
 
         const depthAttachment: GPURenderPassDepthStencilAttachment = {
             view: this.depthTextureView,
-            depthLoadValue: 1,
+            depthClearValue: 1,
+            depthLoadOp: 'clear',
             depthStoreOp: 'store',
-            stencilLoadValue: 'load',
+            stencilLoadOp: 'clear',
             stencilStoreOp: 'store'
         };
 
@@ -260,7 +262,7 @@ export default class Renderer {
         this.passEncoder.setVertexBuffer(1, this.colorBuffer);
         this.passEncoder.setIndexBuffer(this.indexBuffer, 'uint16');
         this.passEncoder.drawIndexed(3, 1);
-        this.passEncoder.endPass();
+        this.passEncoder.end();
 
         this.queue.submit([this.commandEncoder.finish()]);
     }

--- a/src/shaders/triangle.frag.wgsl
+++ b/src/shaders/triangle.frag.wgsl
@@ -1,4 +1,4 @@
-[[stage(fragment)]]
-fn main([[location(0)]] inColor: vec3<f32>) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn main(@location(0) inColor: vec3<f32>) -> @location(0) vec4<f32> {
     return vec4<f32>(inColor, 1.0);
 }

--- a/src/shaders/triangle.vert.wgsl
+++ b/src/shaders/triangle.vert.wgsl
@@ -1,11 +1,11 @@
 struct VSOut {
-    [[builtin(position)]] Position: vec4<f32>;
-    [[location(0)]] color: vec3<f32>;
+    @builtin(position) Position: vec4<f32>;
+    @location(0) color: vec3<f32>;
 };
 
-[[stage(vertex)]]
-fn main([[location(0)]] inPos: vec3<f32>,
-        [[location(1)]] inColor: vec3<f32>) -> VSOut {
+@stage(vertex)
+fn main(@location(0) inPos: vec3<f32>,
+        @location(1) inColor: vec3<f32>) -> VSOut {
     var vsOut: VSOut;
     vsOut.Position = vec4<f32>(inPos, 1.0);
     vsOut.color = inColor;


### PR DESCRIPTION
- Update the shaders to use the new attribute syntax.
- Fix warnings suggesting to specify "clear" load op and "clearValue"
properties over "loadValue/depthLoadValue" when specifying
GPURenderPassColorAttachment and GPURenderPassDepthStencilAttachment.